### PR TITLE
bump python to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers=["Programming Language :: Python :: 3",
                  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
                  "Operating System :: OS Independent",
                  "Topic :: Scientific/Engineering :: Astronomy"]
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 readme = "README.md"
 license = {file = "LICENSE.rst"}
 dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
                  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
                  "Operating System :: OS Independent",
                  "Topic :: Scientific/Engineering :: Astronomy"],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=['numpy',
                       'astropy',
                       'requests',


### PR DESCRIPTION
due to type hints we need python 3.9. Alternative is to use typing module and change the type hints to be backwards compatible.