### PR TITLE
Add API token double check, cache reset of load_config if updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ After doing any of the above, your config.ini will have your API token, and all 
 
 # Dev
 
-After clonening from the github repo, use the provided pyproject.toml file. Install using `flit` (`pip install flit`):
+After cloning from the github repo, use the provided pyproject.toml file. Install using `flit` (`pip install flit`):
 `flit install --symlink` to install in EDITABLE mode. A legacy `setup.py` is also provided for installing with 
 `pip install -e .` from the root directory. Important, do not upload you `config.ini`! Make sure all values are None
 as in the template from Pypi. We welcome all PRs.

--- a/tendrils/utils/config.py
+++ b/tendrils/utils/config.py
@@ -73,7 +73,7 @@ def update_api_token() -> str:
     # We remove spaces from the token to avoid errors.
     token = token.strip().replace(' ', '')
     set_api_token(token, overwrite=True)
-    print(f'Token with value {token} set and saved./nIf there is a problem, please run Tendrils again.')
+    print(f'Token with value {token} set and saved.\nIf there is a problem, please run Tendrils again.')
     return token
 
 
@@ -90,7 +90,7 @@ def get_api_token() -> str:
     if token is None:
         raise RuntimeError("No API token has been defined")
 
-    if token.lower() in ['none', 'test', '']:
+    if token.lower() in ['none', 'test', '', 'bad', 'bad_token', 'badtoken']:
         token = update_api_token()
 
     return token

--- a/tendrils/version.py
+++ b/tendrils/version.py
@@ -4,6 +4,6 @@ Version
 
 major = 0
 minor = 2
-bugfix = 0
+bugfix = 1
 version_info = (major, minor, bugfix)
 version = f"{major}.{minor}.{bugfix}"

--- a/tendrils/version.py
+++ b/tendrils/version.py
@@ -3,7 +3,7 @@ Version
 """
 
 major = 0
-minor = 2
-bugfix = 1
+minor = 3
+bugfix = 0
 version_info = (major, minor, bugfix)
 version = f"{major}.{minor}.{bugfix}"


### PR DESCRIPTION
we reset the lru_cache if using any of the setters for the config file so that the same running instance of tendrils can use the updated config info.

We also added some basic checking to the get api token call to query the user for a valid token if the token is default None, or one of the known invalid ones.